### PR TITLE
Fixes "twitter-tweet" class not found with attribute syntax

### DIFF
--- a/src/Pass/TwitterTransformPass.php
+++ b/src/Pass/TwitterTransformPass.php
@@ -30,7 +30,7 @@ class TwitterTransformPass extends BasePass
 {
     function pass()
     {
-        $all_tweets = $this->q->top()->find('blockquote[class="twitter-tweet"]');
+        $all_tweets = $this->q->top()->find('blockquote[class~="twitter-tweet"]');
         /** @var DOMQuery $el */
         foreach ($all_tweets as $el) {
             /** @var \DOMElement $dom_el */


### PR DESCRIPTION
The module, which generates our twitter embed code adds another class to the `blockquote` element, so the old selector didn't work. 

The used attribute syntax for finding the class "twitter-tweet" only finds it, if it is the only class of the blockquote.
Now it uses following syntax: `[attr~=value]`, which selects the value in a space seperated list ([Read more in the MDN article about Attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors).

Also the normal dot-syntax could be used.

Or am I missing a problem, which lead to the decision to use the old syntax?
